### PR TITLE
Classify will now detect attributes which are user-declared 

### DIFF
--- a/RT.Serialization/Classify.cs
+++ b/RT.Serialization/Classify.cs
@@ -395,7 +395,8 @@ namespace RT.Serialization
                     {
                         yield return match;
                     }
-                    else if ((fuzzyMatch = _classifyAttributes.SingleOrDefault(t => t.Name == attr.GetType().Name)) != null)
+                    // search for any attribute named the same as a known ClassifyAttribute
+                    else if (typeof(T).Name == attr.GetType().Name && (fuzzyMatch = _classifyAttributes.SingleOrDefault(t => t.Name == attr.GetType().Name)) != null)
                     {
                         yield return Activator.CreateInstance<T>();
                     }

--- a/RT.Serialization/Classify.cs
+++ b/RT.Serialization/Classify.cs
@@ -388,7 +388,6 @@ namespace RT.Serialization
                         .ToArray();
                 }
 
-                Type fuzzyMatch;
                 foreach (var attr in attrs)
                 {
                     if (attr is T match)
@@ -396,7 +395,7 @@ namespace RT.Serialization
                         yield return match;
                     }
                     // search for any attribute named the same as a known ClassifyAttribute
-                    else if (typeof(T).Name == attr.GetType().Name && (fuzzyMatch = _classifyAttributes.SingleOrDefault(t => t.Name == attr.GetType().Name)) != null)
+                    else if (typeof(T).Name == attr.GetType().Name && _classifyAttributes.SingleOrDefault(t => t.Name == attr.GetType().Name) != null)
                     {
                         yield return Activator.CreateInstance<T>();
                     }

--- a/RT.Serialization/ClassifyAttributes.cs
+++ b/RT.Serialization/ClassifyAttributes.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace RT.Serialization
+{
+    /// <summary>
+    ///     Serves as a base class for all classify attributes which can be re-declared in your own library, 
+    ///     and is not intended to be used by consumers of Classify directly.</summary>
+    public class ClassifyAttribute : Attribute { }
+
+    /// <summary>
+    ///     If this attribute is used on a field or automatically-implemented property, it is ignored by <see
+    ///     cref="Classify"/>. Data stored in this field or automatically-implemented property is not persisted.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ClassifyIgnoreAttribute : ClassifyAttribute { }
+
+    /// <summary>
+    ///     If this attribute is used on a field or automatically-implemented property, <see cref="Classify"/> omits its
+    ///     serialization if the value is null, 0, false, etc. If it is used on a type, it applies to all fields and
+    ///     automatically-implemented properties in the type. See also remarks.</summary>
+    /// <remarks>
+    ///     <list type="bullet">
+    ///         <item><description>
+    ///             Using this together with <see cref="ClassifyIgnoreIfEmptyAttribute"/> will cause the distinction between
+    ///             null and an empty collection to be lost. However, a collection containing only null elements is persisted
+    ///             correctly.</description></item>
+    ///         <item><description>
+    ///             Do not use this custom attribute on a field that has a non-default value set in the containing class’s
+    ///             constructor. Doing so will cause a serialized null/0/false value to revert to that constructor value upon
+    ///             deserialization.</description></item></list></remarks>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Struct, Inherited = true)]
+    public sealed class ClassifyIgnoreIfDefaultAttribute : ClassifyAttribute { }
+
+    /// <summary>
+    ///     If this attribute is used on a field or automatically-implemented property, <see cref="Classify"/> omits its
+    ///     serialization if that serialization would be completely empty. If it is used on a type, it applies to all
+    ///     collection-type fields in the type. See also remarks.</summary>
+    /// <remarks>
+    ///     Using this together with <see cref="ClassifyIgnoreIfDefaultAttribute"/> will cause the distinction between null
+    ///     and an empty collection to be lost. However, a collection containing only null elements is persisted correctly.</remarks>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Struct, Inherited = true)]
+    public sealed class ClassifyIgnoreIfEmptyAttribute : ClassifyAttribute { }
+
+    /// <summary>
+    ///     Specifies that Classify shall not set this field or automatically-implemented property to <c>null</c>. If the
+    ///     serialized form is <c>null</c>, the field or automatically-implemented property is instead left at the default
+    ///     value assigned by the object’s default constructor.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ClassifyNotNullAttribute : ClassifyAttribute { }
+
+    /// <summary>
+    ///     To be used on a field or automatically-implemented property of an enum type or a collection involving an enum
+    ///     type. Specifies that Classify shall not allow integer values that are not explicitly declared in the relevant enum
+    ///     type. If the serialized form is such an integer, fields or automatically-implemented properties of an enum type
+    ///     are instead left at the default value assigned by the object’s default constructor, while in collections, the
+    ///     relevant element is omitted (changing the size of the collection). If the enum type has the [Flags] attribute,
+    ///     bitwise combinations of the declared values are allowed.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ClassifyEnforceEnumAttribute : ClassifyAttribute { }
+
+    internal static class ClassifyAttributeExtensions
+    {
+        public static bool IsDefinedOrIsNamedLike<T>(this MemberInfo member, bool inherit = false)
+        {
+            return member.IsDefined(typeof(T), inherit) || member.GetCustomAttributes(inherit).Any(a => a.GetType().Name == typeof(T).Name);
+        }
+    }
+}

--- a/RT.Serialization/ClassifyAttributes.cs
+++ b/RT.Serialization/ClassifyAttributes.cs
@@ -1,19 +1,15 @@
 ﻿using System;
-using System.Linq;
-using System.Reflection;
 
 namespace RT.Serialization
 {
     /// <summary>
-    ///     Serves as a base class for all classify attributes which can be re-declared in your own library, 
-    ///     and is not intended to be used by consumers of Classify directly.</summary>
-    public class ClassifyAttribute : Attribute { }
-
-    /// <summary>
     ///     If this attribute is used on a field or automatically-implemented property, it is ignored by <see
     ///     cref="Classify"/>. Data stored in this field or automatically-implemented property is not persisted.</summary>
+    /// <remarks>
+    ///     Any attribute with this type name is accepted by <see cref="Classify"/> to mean the same thing, regardless of
+    ///     where it is declared, making it possible to apply this attribute without referencing this library.</remarks>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class ClassifyIgnoreAttribute : ClassifyAttribute { }
+    public sealed class ClassifyIgnoreAttribute : Attribute { }
 
     /// <summary>
     ///     If this attribute is used on a field or automatically-implemented property, <see cref="Classify"/> omits its
@@ -28,26 +24,38 @@ namespace RT.Serialization
     ///         <item><description>
     ///             Do not use this custom attribute on a field that has a non-default value set in the containing class’s
     ///             constructor. Doing so will cause a serialized null/0/false value to revert to that constructor value upon
-    ///             deserialization.</description></item></list></remarks>
+    ///             deserialization.</description></item>
+    ///         <item><description>
+    ///             Any attribute with this type name is accepted by <see cref="Classify"/> to mean the same thing, regardless
+    ///             of where it is declared, making it possible to apply this attribute without referencing this library.</description></item></list></remarks>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Struct, Inherited = true)]
-    public sealed class ClassifyIgnoreIfDefaultAttribute : ClassifyAttribute { }
+    public sealed class ClassifyIgnoreIfDefaultAttribute : Attribute { }
 
     /// <summary>
     ///     If this attribute is used on a field or automatically-implemented property, <see cref="Classify"/> omits its
     ///     serialization if that serialization would be completely empty. If it is used on a type, it applies to all
     ///     collection-type fields in the type. See also remarks.</summary>
     /// <remarks>
-    ///     Using this together with <see cref="ClassifyIgnoreIfDefaultAttribute"/> will cause the distinction between null
-    ///     and an empty collection to be lost. However, a collection containing only null elements is persisted correctly.</remarks>
+    ///     <list type="bullet">
+    ///         <item><description>
+    ///             Using this together with <see cref="ClassifyIgnoreIfDefaultAttribute"/> will cause the distinction between
+    ///             null and an empty collection to be lost. However, a collection containing only null elements is persisted
+    ///             correctly.</description></item>
+    ///         <item><description>
+    ///             Any attribute with this type name is accepted by <see cref="Classify"/> to mean the same thing, regardless
+    ///             of where it is declared, making it possible to apply this attribute without referencing this library.</description></item></list></remarks>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Struct, Inherited = true)]
-    public sealed class ClassifyIgnoreIfEmptyAttribute : ClassifyAttribute { }
+    public sealed class ClassifyIgnoreIfEmptyAttribute : Attribute { }
 
     /// <summary>
     ///     Specifies that Classify shall not set this field or automatically-implemented property to <c>null</c>. If the
     ///     serialized form is <c>null</c>, the field or automatically-implemented property is instead left at the default
     ///     value assigned by the object’s default constructor.</summary>
+    /// <remarks>
+    ///     Any attribute with this type name is accepted by <see cref="Classify"/> to mean the same thing, regardless of
+    ///     where it is declared, making it possible to apply this attribute without referencing this library.</remarks>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class ClassifyNotNullAttribute : ClassifyAttribute { }
+    public sealed class ClassifyNotNullAttribute : Attribute { }
 
     /// <summary>
     ///     To be used on a field or automatically-implemented property of an enum type or a collection involving an enum
@@ -56,14 +64,9 @@ namespace RT.Serialization
     ///     are instead left at the default value assigned by the object’s default constructor, while in collections, the
     ///     relevant element is omitted (changing the size of the collection). If the enum type has the [Flags] attribute,
     ///     bitwise combinations of the declared values are allowed.</summary>
+    /// <remarks>
+    ///     Any attribute with this type name is accepted by <see cref="Classify"/> to mean the same thing, regardless of
+    ///     where it is declared, making it possible to apply this attribute without referencing this library.</remarks>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class ClassifyEnforceEnumAttribute : ClassifyAttribute { }
-
-    internal static class ClassifyAttributeExtensions
-    {
-        public static bool IsDefinedOrIsNamedLike<T>(this MemberInfo member, bool inherit = false)
-        {
-            return member.IsDefined(typeof(T), inherit) || member.GetCustomAttributes(inherit).Any(a => a.GetType().Name == typeof(T).Name);
-        }
-    }
+    public sealed class ClassifyEnforceEnumAttribute : Attribute { }
 }

--- a/Tests/RT.Serialization.Tests/ClassifyTests.cs
+++ b/Tests/RT.Serialization.Tests/ClassifyTests.cs
@@ -2456,6 +2456,35 @@ namespace RT.Serialization.Tests
             Assert.Throws<InvalidOperationException>(() => { ClassifyJson.Serialize(new ClassWithClassifyNameAttributeOnType()); });
             Assert.Throws<InvalidOperationException>(() => { ClassifyJson.Deserialize<ClassWithClassifyNameAttributeOnType>(new JsonDict()); });
         }
+
+        class ClassWithUserDefinedAttributeOne
+        {
+            [ClassifyIgnore]
+            public string One = "One";
+            public string Two = "Two";
+        }
+
+        class ClassWithUserDefinedAttributeTwo
+        {
+            [UserDefined.ClassifyIgnore]
+            public string One = "One";
+            public string Two = "Two";
+        }
+
+        [Test]
+        public void TestUserDefinedAttribute()
+        {
+            var j1 = ClassifyJson.Serialize(new ClassWithUserDefinedAttributeOne());
+            var j2 = ClassifyJson.Serialize(new ClassWithUserDefinedAttributeTwo());
+
+            Assert.AreEqual(j1.ToString(), j2.ToString());
+
+            Assert.IsFalse(j1.ContainsKey("One"));
+            Assert.IsFalse(j2.ContainsKey("One"));
+
+            Assert.IsTrue(j1.ContainsKey("Two"));
+            Assert.IsTrue(j2.ContainsKey("Two"));
+        }
     }
 
     class MisTypeOuter
@@ -2464,4 +2493,11 @@ namespace RT.Serialization.Tests
     }
     abstract class MisTypeBase { }
     class MisTypeDerived : MisTypeBase { }
+
+
+}
+
+namespace UserDefined
+{
+    class ClassifyIgnoreAttribute : Attribute { }
 }


### PR DESCRIPTION
This allows Classify to detect simple attributes declared in the user's own assembly that are named the same as a Classify attribute. 

For example, creating a class like this is valid, does not require a reference to Classify, and will omit the properties
``` cs
namespace My.Awesome.Program {
    class MyAwesomeClass {
        [ClassifyIgnore]
        public UnserializableType Worker { get; set; }
    }
    class ClassifyIgnore : Attribute { }
}
```

In addition, the attributes that Classify will automatically detect are moved to a separate file to make them easier to copy from here into your own class library