### PR TITLE
Add text/string overloads where "JsonValue" is accepted in ClassifyJson

### DIFF
--- a/RT.Serialization.Json/ClassifyJson.cs
+++ b/RT.Serialization.Json/ClassifyJson.cs
@@ -57,6 +57,23 @@ namespace RT.Serialization
         /// <typeparam name="T">
         ///     Type of object to reconstruct.</typeparam>
         /// <param name="json">
+        ///     Json string to reconstruct object from.</param>
+        /// <param name="options">
+        ///     Options.</param>
+        /// <param name="format">
+        ///     Implementation of a Classify format. See <see cref="ClassifyJsonFormat"/> for an example.</param>
+        /// <returns>
+        ///     A new instance of the requested type.</returns>
+        public static T Deserialize<T>(string json, ClassifyOptions options = null, IClassifyFormat<JsonValue> format = null)
+        {
+            return Classify.Deserialize<JsonValue, T>(JsonValue.Parse(json), format ?? DefaultFormat, options);
+        }
+
+        /// <summary>
+        ///     Reconstructs an object of the specified type from the specified serialized form.</summary>
+        /// <typeparam name="T">
+        ///     Type of object to reconstruct.</typeparam>
+        /// <param name="json">
         ///     Serialized form to reconstruct object from.</param>
         /// <param name="options">
         ///     Options.</param>
@@ -74,6 +91,23 @@ namespace RT.Serialization
         /// <param name="type">
         ///     Type of object to reconstruct.</param>
         /// <param name="json">
+        ///     Json string to reconstruct object from.</param>
+        /// <param name="options">
+        ///     Options.</param>
+        /// <param name="format">
+        ///     Implementation of a Classify format. See <see cref="ClassifyJsonFormat"/> for an example.</param>
+        /// <returns>
+        ///     A new instance of the requested type.</returns>
+        public static object Deserialize(Type type, string json, ClassifyOptions options = null, IClassifyFormat<JsonValue> format = null)
+        {
+            return Classify.Deserialize(type, JsonValue.Parse(json), format ?? DefaultFormat, options);
+        }
+
+        /// <summary>
+        ///     Reconstructs an object of the specified type from the specified serialized form.</summary>
+        /// <param name="type">
+        ///     Type of object to reconstruct.</param>
+        /// <param name="json">
         ///     Serialized form to reconstruct object from.</param>
         /// <param name="options">
         ///     Options.</param>
@@ -84,6 +118,24 @@ namespace RT.Serialization
         public static object Deserialize(Type type, JsonValue json, ClassifyOptions options = null, IClassifyFormat<JsonValue> format = null)
         {
             return Classify.Deserialize(type, json, format ?? DefaultFormat, options);
+        }
+
+        /// <summary>
+        ///     Reconstructs an object of the specified type from the specified serialized form by applying the values to an
+        ///     existing instance of the type.</summary>
+        /// <typeparam name="T">
+        ///     Type of object to reconstruct.</typeparam>
+        /// <param name="json">
+        ///     Json string to reconstruct object from.</param>
+        /// <param name="intoObject">
+        ///     Object to assign values to in order to reconstruct the original object.</param>
+        /// <param name="options">
+        ///     Options.</param>
+        /// <param name="format">
+        ///     Implementation of a Classify format. See <see cref="ClassifyJsonFormat"/> for an example.</param>
+        public static void DeserializeIntoObject<T>(string json, T intoObject, ClassifyOptions options = null, IClassifyFormat<JsonValue> format = null)
+        {
+            Classify.DeserializeIntoObject(JsonValue.Parse(json), intoObject, format ?? DefaultFormat, options);
         }
 
         /// <summary>


### PR DESCRIPTION
The current ClassifyJson overloads are error-prone when deserializing from string because JsonValue has an implicit operator for string which enables the following:

``` cs
string json = "{ ... }";
var obj = ClassifyJson.Deserialize<TObj>(json);
```

This is a natural usage for anyone familiar with Newtonsoft, however it will result in classify (silently) failing to deserialize the object as it is treating the input as a string instead of an object. 

The added overloads will take priority over the implicit operator and correctly parse the incoming object.