### PR TITLE
NumericExtensions: Correct misspelled argument

### DIFF
--- a/RT.Util.Core/ExtensionMethods/NumericExtensions.cs
+++ b/RT.Util.Core/ExtensionMethods/NumericExtensions.cs
@@ -19,7 +19,7 @@ namespace RT.Util.ExtensionMethods
         /// <summary>Clips this value so that it is no less than the minimum value specified.</summary>
         public static int ClipMin(this int value, int minimumValue) { return value <= minimumValue ? minimumValue : value; }
         /// <summary>Clips this value so that it is no greater than the maximum value specified.</summary>
-        public static int ClipMax(this int value, int maxnimumValue) { return value >= maxnimumValue ? maxnimumValue : value; }
+        public static int ClipMax(this int value, int maximumValue) { return value >= maximumValue ? maximumValue : value; }
 
         /// <summary>
         ///     Clips this value to the range defined by <paramref name="minimumValue"/> and <paramref name="maximumValue"/>.
@@ -35,7 +35,7 @@ namespace RT.Util.ExtensionMethods
         /// <summary>Clips this value so that it is no less than the minimum value specified.</summary>
         public static double ClipMin(this double value, double minimumValue) { return value <= minimumValue ? minimumValue : value; }
         /// <summary>Clips this value so that it is no greater than the maximum value specified.</summary>
-        public static double ClipMax(this double value, double maxnimumValue) { return value >= maxnimumValue ? maxnimumValue : value; }
+        public static double ClipMax(this double value, double maximumValue) { return value >= maximumValue ? maximumValue : value; }
 
         /// <summary>
         ///     Clips this value to the range defined by <paramref name="minimumValue"/> and <paramref name="maximumValue"/>.
@@ -51,7 +51,7 @@ namespace RT.Util.ExtensionMethods
         /// <summary>Clips this value so that it is no less than the minimum value specified.</summary>
         public static decimal ClipMin(this decimal value, decimal minimumValue) { return value <= minimumValue ? minimumValue : value; }
         /// <summary>Clips this value so that it is no greater than the maximum value specified.</summary>
-        public static decimal ClipMax(this decimal value, decimal maxnimumValue) { return value >= maxnimumValue ? maxnimumValue : value; }
+        public static decimal ClipMax(this decimal value, decimal maximumValue) { return value >= maximumValue ? maximumValue : value; }
 
         /// <summary>
         ///     Determines whether <paramref name="value"/> is between <paramref name="min"/> and <paramref name="max"/>


### PR DESCRIPTION
`maxnimumValue` is misspelled, this pull request changes them to `maximumValue`.